### PR TITLE
feat:profile 수정 페이지 구현

### DIFF
--- a/app/src/main/java/bitcamp/show_pet/member/controller/MemberController.java
+++ b/app/src/main/java/bitcamp/show_pet/member/controller/MemberController.java
@@ -192,6 +192,7 @@ public class MemberController {
   @PostMapping("update")
   public String update(
       Member member,
+      HttpSession session,
       MultipartFile photofile) throws Exception {
 
     if (photofile.getSize() > 0) {
@@ -203,6 +204,7 @@ public class MemberController {
     if (memberService.update(member) == 0) {
       throw new Exception("회원이 없습니다.");
     } else {
+      session.setAttribute("loginUser", member);
       return "redirect:../post/list";
     }
 

--- a/app/src/main/resources/static/css/memberDetail.css
+++ b/app/src/main/resources/static/css/memberDetail.css
@@ -1,0 +1,251 @@
+#imagePreview {
+    width: 100px;
+    height: 100px;
+    overflow: hidden;
+    border-radius: 50%;
+}
+
+#imagePreview img {
+    width: 100%;
+    height: 100%; /* 이미지를 박스에 꽉 채우도록 설정합니다. */
+    border-radius: 50%;
+    object-fit: cover; /* 이미지 비율을 유지하면서 박스에 맞춥니다. */
+}
+.update-container {
+    box-sizing: border-box;
+    padding: 3.8rem 3.8rem 1rem 3.8rem;
+    width: 100%;
+    overflow: hidden;
+    position: relative;
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    background-color: #ffffff;
+    border-radius: 1.5rem;
+}
+.upload-container {
+    justify-content: center; /* 세로 중앙 정렬을 위한 추가 코드 */
+    align-items: center; /* 내용을 세로 중앙에 정렬 */
+}
+.profile-container {
+    display: flex;
+    align-items: center; /* 세로 중앙 정렬 */
+}
+.reset-container{
+    display: flex; /* Flexbox를 활성화합니다. */
+    justify-content: center; /* 가로 정렬을 중앙에 설정합니다. */
+    align-items: center; /* 세로 정렬을 중앙에 설정합니다. */
+}
+
+.profile-round-image {
+    border-radius: 50%; /* 동그라미 모양으로 만듭니다. */
+    overflow: hidden; /* 넘치는 부분을 숨깁니다. */
+    width: 200px; /* 이미지의 너비 조정 */
+    height: 200px; /* 이미지의 높이 조정 */
+    margin-bottom: 50px;
+    margin-left: 7rem;
+}
+
+.profile-round-image img {
+    width: 100%; /* 이미지를 박스에 꽉 채우도록 설정합니다. */
+    height: 100%; /* 이미지를 박스에 꽉 채우도록 설정합니다. */
+    object-fit: cover; /* 이미지 비율을 유지하면서 박스에 맞춥니다. */
+}
+
+.profile-preview {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%; /* 동그라미 모양으로 설정 */
+}
+.preview-container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: absolute;
+    top: 0;
+    left: 0;
+    opacity: 0;
+    background-color: rgba(0, 0, 0, 0.6); /* 미리보기 영역의 배경색과 투명도 설정 */
+    border-radius: 50%;
+}
+.profile-round-image:hover .preview-container {
+    opacity: 1;
+}
+
+input[type="file"] {
+    display: none;
+}
+button[type='reset'],
+a[href='../post/list'] {
+    display: inline-block;
+    margin-right: 10px; /* 원하는 간격 설정 */
+}
+
+.reset-button {
+    background-color: #504e4d;
+    color: white;
+    text-align: center;
+    width: 8rem;
+    height: 3rem;
+    font-size: 20px;
+    text-decoration: none;
+    padding: 10px 20px;
+    border: none;
+    cursor: pointer;
+    display: inline-block;
+    border-radius: 16px;
+}
+.reset-button:hover {
+    background-color: #f05400;
+}
+
+/* 사용자 정의 스타일을 가진 버튼 */
+.edit-profile-button {
+    background-color: #504e4d;
+    color: white;
+    text-align: center;
+    text-decoration: none;
+    padding: 10px 20px;
+    border: none;
+    cursor: pointer;
+    display: inline-block;
+    border-radius: 16px;
+}
+
+.edit-profile-button:hover {
+    background-color: #f05400;
+}
+
+.button-box {
+    margin-top: 3.9633rem;
+    margin-bottom: 1rem;
+    width: 45rem;
+    height: 5.966rem;
+    font-size: 1.6rem;
+    font-weight: 700;
+    line-height: 1.5;
+    color: #ffffff;
+    font-family: ABeeZee, 'Source Sans Pro';
+    white-space: nowrap;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 0.4rem 1.9rem rgba(119, 147, 65, 0.3000000119);
+    background-color: #f05400;
+    border-radius: 1rem;
+    flex-shrink: 0;
+    border: none; /* 테두리 제거 */
+    cursor: pointer; /*회원가입 하기에 마우스올릴시 포인터 변경*/
+}
+/*.input-box {*/
+/*    width: 200px; !* 입력 필드의 너비 조정 *!*/
+/*    height: 30px; !* 입력 필드의 높이 조정 *!*/
+/*    font-size: 16px;*/
+/*    font-weight: 700;*/
+/*    color: #000000;*/
+/*    font-family: ABeeZee, 'Source Sans Pro';*/
+/*    display: inline-block;*/
+/*    vertical-align: middle; !* 세로 가운데 정렬 추가 *!*/
+/*}*/
+
+.input-box {
+    width: 400px;
+    height: 48px;
+    font-size: 15px;
+    font-weight: 700;
+    color: #000000;
+    font-family: ABeeZee, 'Source Sans Pro';
+    border-radius: 1rem;
+    flex-shrink: 0;
+    margin-bottom: 30px;
+    vertical-align: middle;
+    border: 1px solid #d3d3d3; /* 검은색 테두리 추가 */
+    transition: border-color 0.3s; /* 테두리 색상 변화에 트랜지션 적용 */
+}
+.password-box {
+        width: 400px;
+        height: 48px;
+        font-size: 15px;
+        font-weight: 700;
+        color: #000000;
+        font-family: ABeeZee, 'Source Sans Pro';
+        border-radius: 1rem;
+        flex-shrink: 0;
+        margin-bottom: 30px;
+        vertical-align: middle;
+        border: 1px solid #d3d3d3; /* 검은색 테두리 추가 */
+    transition: border-color 0.3s; /* 테두리 색상 변화에 트랜지션 적용 */
+    }
+
+.text-box {
+    width: 536px;
+    height: 120px;
+    font-size: 15px;
+    font-weight: 700;
+    line-height: 1.5;
+    color: #000000;
+    font-family: ABeeZee, 'Source Sans Pro';
+    white-space: nowrap;
+    display: inline-block;
+    vertical-align: top;
+    align-items: center;
+    justify-content: center;
+    border-radius: 1rem;
+    flex-shrink: 0;
+    margin-bottom: 30px;
+    border: 1px solid #d3d3d3; /*테두리 추가 */
+    resize: none;
+    transition: border-color 0.3s; /* 테두리 색상 변화에 트랜지션 적용 */
+}
+
+
+.text {
+    font-size: 16px;
+    font-weight: 700;
+    color: #000000;
+    font-family: Rammetto One, 'Source Sans Pro';
+    vertical-align: top;
+}
+
+.intro-box {
+    width: 100%;
+    font-size: 25px;
+    font-weight: 700;
+    color: #000000;
+    font-family: ABeeZee, 'Source Sans Pro';
+    display: inline-block;
+    vertical-align: top;
+    margin-bottom: 30px;
+    resize: none;
+    text-align: center;
+}
+
+.intro-text {
+    font-size: 16px;
+    font-weight: 700;
+    color: #000000;
+    font-family: Rammetto One, 'Source Sans Pro';
+    vertical-align: top;
+}
+
+.pet-category {
+    width: 400px;
+    height: 48px;
+    border-radius: 1rem;
+    border: 1px solid #d3d3d3; /* 선택되지 않은 상태의 테두리 색상 */
+    transition: border-color 0.3s; /* 테두리 색상 변화에 트랜지션 적용 */
+
+    color: #000;
+}
+
+/* 선택되었을 때의 스타일 */
+.pet-category:focus {
+    border-color: black; /* 선택될 때 테두리 색상 변경 */
+    background-color: white; /* 선택될 때 배경색 변경 */
+    color: #000; /* 선택될 때 글자색 변경 */
+    cursor: auto; /* 선택될 때 기본 커서 모양으로 변경 */
+}
+

--- a/app/src/main/resources/static/js/GoToMainpage.js
+++ b/app/src/main/resources/static/js/GoToMainpage.js
@@ -1,0 +1,3 @@
+function goToMainPage() {
+    window.location.href = '/'; // 메인 페이지의 주소로 변경
+}

--- a/app/src/main/resources/static/js/PreviewImage.js
+++ b/app/src/main/resources/static/js/PreviewImage.js
@@ -1,0 +1,20 @@
+function previewImage(input) {
+    const imagePreview = document.getElementById('imagePreview');
+
+    if (input.files && input.files[0]) {
+        const reader = new FileReader();
+
+        reader.onload = function(e) {
+            const preview = document.createElement('img');
+            preview.src = e.target.result;
+            preview.style.maxWidth = '100%';
+            imagePreview.innerHTML = '';
+            imagePreview.appendChild(preview);
+        };
+
+        reader.readAsDataURL(input.files[0]);
+    } else {
+        // 파일이 선택되지 않은 경우 이미지 미리보기를 제거
+        imagePreview.innerHTML = '';
+    }
+}

--- a/app/src/main/resources/static/js/ResetPreviewImage.js
+++ b/app/src/main/resources/static/js/ResetPreviewImage.js
@@ -1,0 +1,4 @@
+function resetPreviewImage() {
+    const imagePreview = document.getElementById('imagePreview');
+    imagePreview.innerHTML = ''; // 이미지 미리보기 제거
+}

--- a/app/src/main/resources/static/js/TextArea.js
+++ b/app/src/main/resources/static/js/TextArea.js
@@ -1,0 +1,15 @@
+var textarea = document.getElementById('myTextarea');
+var charCount = document.getElementById('charCount');
+var maxLength = 50; // 최대 글자 수 지정
+
+textarea.addEventListener('input', function() {
+    var text = textarea.value;
+    var currentLength = text.length;
+
+    if (currentLength > maxLength) {
+        textarea.value = text.substring(0, maxLength); // 최대 글자 수로 제한
+        currentLength = maxLength;
+    }
+
+    charCount.textContent = currentLength + ' / ' + maxLength + ' 글자';
+});

--- a/app/src/main/resources/templates/header.html
+++ b/app/src/main/resources/templates/header.html
@@ -24,10 +24,10 @@
         <div  class="header-container" data-th-if="${session.loginUser != null}">
             <div class="round-image">
                 <a data-th-href="@{'/member/myPage/' + ${session.loginUser.getId()}}">
-                    <img style="width: 50px; height: 50px;" data-th-if="${session.loginUser.photo == null}" th:src="@{/images/avatar.png}"></a>
+                    <img style="width: 50px; height: 50px;" data-th-if="${session.loginUser.getPhoto() == null}" th:src="@{/images/avatar.png}"></a>
                 <a data-th-href="@{'/member/myPage/' + ${session.loginUser.getId()}}">
-                    <img data-th-if="${session.loginUser.photo != null}"
-                         data-th-src="|https://kr.object.ncloudstorage.com/bitcamp-nc7-bucket-16/member/${session.loginUser.photo}|"></a>
+                    <img data-th-if="${session.loginUser.getPhoto() != null}"
+                         data-th-src="|https://kr.object.ncloudstorage.com/bitcamp-nc7-bucket-16/member/${session.loginUser.getPhoto()}|"></a>
             </div>
             <span style="margin-right: 40px" data-th-text="${session.loginUser.getNickName()}"></span>
             <a href="/member/logout"><button class="login-button">로그아웃</button></a>

--- a/app/src/main/resources/templates/member/detail.html
+++ b/app/src/main/resources/templates/member/detail.html
@@ -3,6 +3,14 @@
 <head>
     <meta charset='UTF-8'>
     <title>회원</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Rammetto+One%3A400"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro%3A400%2C700"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=ABeeZee%3A400"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Poppins%3A700"/>
+    <link rel="stylesheet" th:href="@{/css/header.css}"/>
+    <link rel="stylesheet" th:href="@{/css/memberDetail.css}"/>
+    <link rel="stylesheet" th:href="@{/css/index.css}"/>
 </head>
 <body>
 
@@ -12,37 +20,50 @@
 <p data-th-unless="${member}">해당 번호의 회원이 없습니다!</p>
 <form data-th-if="${member}" data-th-action="@{/member/update}" method='post' enctype='multipart/form-data'>
     <input type="hidden" name="id" data-th-value="${member.id}">
-    <table border='1'>
-        <tr>
-            <th style='width:120px;'>사진</th>
-            <td style='width:300px;'>
-                <img data-th-unless="${member.photo}" style="width:50px; height: 50px;" src='/images/avatar.jpeg' >
-                <a data-th-if="${member.photo}"
-                   data-th-href="|https://kr.object.ncloudstorage.com/bitcamp-nc7-bucket-16/member/${member.photo}|">
-                    <img data-th-src="|http://guosqxeocfoi19010728.cdn.ntruss.com/member2/${member.photo}?type=f&w=50&h=50&align=4&faceopt=true&quality=90&autorotate=true&anilimit=100&ttype=jpg|">
-                </a>
-                <input type='file' name='photofile'></td>
-        </tr>
-        <tr>
-            <th>닉네임</th>
-            <td><input type='text' name='nickName' data-th-value="${member.nickName}"></td>
-        </tr>
-        <tr>
-            <th>소개글</th>
-            <td><input type='intro' name='intro' data-th-value="${member.intro}"></td>
-        </tr>
-        <tr>
-            <th>암호</th>
-            <td><input type='password' name='password'></td>
-        </tr>
-    </table>
+    <div class="update-container">
+        <div class="profile-container">
+            <div class="profile-round-image">
+                <img data-th-unless="${member.photo}" src='/images/avatar.png'>
+                <img data-th-src="|https://kr.object.ncloudstorage.com/bitcamp-nc7-bucket-16/member/${member.photo}|">
+            </div>
+            <input type="file" id="fileInput" name='photofile' accept="image/*" onchange="previewImage(this);">
+            <div class="upload-container">
+                <div id="imagePreview"></div>
+                <label for="fileInput" class="edit-profile-button">사진변경</label>
+            </div>
+            <script th:src="@{/js/PreviewImage.js}"></script>
+        </div>
+        <span class="intro-box" th:text="${member.intro}"></span>
+        <label class="intro-text" for="myTextarea">소개글</label>
+        <textarea class="text-box" id="myTextarea" name="intro" data-th-value="${member.intro}"
+                  placeholder="최대 글자수는 띄어쓰기 포함 50자로 제한됩니다"></textarea>
+        <script th:src="@{/js/TextArea.js}"></script>
+        <br>
+        <label class="text" for="password">비밀번호</label>
+        <input class="password-box" type="password" id="password" name="password" placeholder="변경할 비밀번호를 입력해주세요">
 
-    <div>
-        <button>변경</button>
-        <button type='reset'>초기화</button>
-        <a href='../../post/list'>뒤로가기</a>
+        <br>
+        <label class="text" for="nickname">닉네임</label>
+        <input class="input-box" type="text" id="nickname" name="nickName" data-th-value="${member.nickName}">
+
+        <label class="text" for="nickname">선호동물 변경</label>
+        <select class="pet-category" id="petName" name='category'>
+            <option value='2'>강아지</option>
+            <option value='3'>고양이</option>
+            <option value='4'>새</option>
+            <option value='1'>기타</option>
+        </select>
+
+        <button type="submit" class="button-box">변경확인</button>
+
+
+    </div>
+    <div class="reset-container">
+        <button type='reset' class="reset-button" onclick="resetPreviewImage()">초기화</button>
+        <script th:src="@{/js/ResetPreviewImage.js}"></script>
+        <button type="button" class="reset-button" onclick="goToMainPage()">메인</button>
+        <script th:src="@{/js/GoToMainpage.js}"></script>
     </div>
 </form>
-
 </body>
 </html>


### PR DESCRIPTION
- 회원정보 페이지 구현
- 현재 애로사항 : 소개글에서 textarea영역에 아무 값도 넣지 않고 회원정보 변경 시 소개글에 빈값이 넘어갑니다 또한
프로필 사진 수정 시 헤더에 바로 반영이 되지 않아서 member컨트롤러에 update부분에 세션을 다시 생성하여 프로필 수정시 사진이 바로 반영되게 하였으나 다시 프로필 사진을 아무 값도 넣지 않고 회원정보 변경시 다른곳은 사진이 원래 사진으로 정상적으로 나오나 헤더에 기본 이미지 사진으로 변경됩니다..